### PR TITLE
DPA: Update Subprocessor List

### DIFF
--- a/dpa-subprocessors/index.md
+++ b/dpa-subprocessors/index.md
@@ -6,12 +6,13 @@ description: >
   A list of Tailscale's data subprocessors and the kinds of data they handle.
 ---
 
-**Last Updated: 2024-10-28**
+**Last Updated: 2025-09-02**
 | Subprocessor | Purpose of Processing | Data processed | Location |
 | --- | --- | --- | --- |
 | AWS | Cloud hosting provider | Client device and node information; Configuration information | United States, European Economic Area |
 | DigitalOcean | Cloud hosting provider for DERP servers | Client device and node information; Configuration information | United States, European Economic Area |
 | Hetzner | Cloud hosting provider for DERP servers | Client device and node information; Configuration information | United States, European Economic Area |
+| Linode | Cloud hosting provider for DERP servers | Client device and node information; Configuration information | United States |
 | Snowflake | Cloud-based data warehouse | Client device and node information; Configuration information | United States |
 | Vultr | Cloud hosting provider for DERP servers | Client device and node information; Configuration information | United States, European Economic Area |
 | NetActuate | Cloud hosting provider for DERP servers | Client device and node information; Configuration information | United States |


### PR DESCRIPTION
This PR serves as a notification to customers to inform that we have updated our Subprocessor List.

What’s changed?

We have added the following subprocessor(s):

Subprocessor
Linode

Purpose of Processing
Cloud hosting provider for DERP servers

Data Processed
Client device and node information; Configuration information

Location
United States

Please take the time to review the new change(s) above. An archive of our subprocessor list is available here in case you wish to compare. If you have any questions, please reach out to privacy@tailscale.com

Thank you,
The Tailscale Team