### PR TITLE
[BG-1617, BG-1619] add code of conduct and refund policy files

### DIFF
--- a/code-of-conduct/index.md
+++ b/code-of-conduct/index.md
@@ -1,0 +1,41 @@
+---
+title: Code of Conduct
+slug: code-of-conduct
+layout: legal
+description: >
+  Tailscale events code of conduct.
+---
+
+## Our Pledge
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community. Tailscale and its communities are dedicated to providing a harassment-free experience for participants at all of our events, whether they are held in person or virtually. They exist to encourage the open exchange of ideas and expression. They require an environment that recognizes the inherent worth of every person and group. While at Tailscale events or related ancillary or social events, any participants, including members, speakers, attendees, volunteers, sponsors, exhibitors, booth staff and anyone else, should not engage in harassment in any form.
+
+This Events Code of Conduct may be revised at any time by Tailscale and the terms are non-negotiable. Registration for or attendance at any Tailscale event, whether it's held in person or virtually, indicates your agreement to abide by this policy and its terms.
+
+## Expected Behavior
+All event participants, whether they are attending an in-person event or a virtual event, are expected to behave in accordance with professional standards, with both this Events Code of Conduct as well as their respective employer's policies governing appropriate workplace behavior and applicable laws.
+
+## Unacceptable Behavior
+Harassment will not be tolerated in any form, whether in person or virtually. Harassment includes the use of abusive, offensive or degrading language, intimidation, stalking, harassing photography or recording, inappropriate physical contact, sexual imagery and unwelcome sexual advances or requests for sexual favors. Any report of harassment at one of our events, whether in person or virtual, will be addressed immediately. Participants asked to stop any harassing behavior are expected to comply immediately. Anyone who witnesses or is subjected to unacceptable behavior should notify a conference organizer at once.
+
+## Consequences of Unacceptable Behavior
+If a participant engages in harassing behavior, whether in person or virtually, the event organizers may take any action they deem appropriate depending on the circumstances, ranging from issuance of a warning to the offending individual to expulsion from the conference with no refund. Tailscale reserves the right to exclude any participant found to be engaging in harassing behavior from participating in any further Tailscale events, trainings or other activities.
+
+If a participant (or individual wishing to participate in a Tailscale event, in-person and/or virtual), through postings on social media or other online publications or another form of electronic communication, engages in conduct that violates this policy, whether before, during or after a Tailscale event, Tailscale may take appropriate corrective action, which could include imposing a temporary or permanent ban on an individual's participation in future Tailscale events.
+
+## What To Do If You Witness or Are Subject To Unacceptable Behavior
+If you are being harassed, notice that someone else is being harassed, or have any other concerns relating to harassment, please contact a member of the conference staff immediately. You are also encouraged to contact Katie Reese, Senior Events Manager, at katie@tailscale.com.
+
+## Incident Response
+If a participant engages in harassing behavior, whether in-person or virtually, the conference organizers may take any action they deem appropriate, ranging from issuance of a warning to the offending individual to expulsion from the conference with no refund, depending on the circumstances. Tailscale reserves the right to exclude any participant found to be engaging in harassing behavior from participating in any further Tailscale events, trainings or other activities.
+
+Conference staff will also provide support to victims, including, but not limited to:
+
+- **Providing an escort.**
+- **Contacting hotel/venue security or local law enforcement.**
+- **Briefing key event staff for response/victim assistance.**
+- **And otherwise assisting those experiencing harassment to ensure that they feel safe for the duration of the conference.**
+
+## Attribution
+This Code of Conduct is adapted from [Tailscale's Contributor Covenant Code of Conduct](https://github.com/tailscale/tailscale/blob/main/CODE_OF_CONDUCT.md), the [Linux Foundation's event Code of Conduct](https://events.linuxfoundation.org/about/code-of-conduct/) and the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.0 available [here](https://www.notion.so/2eed917d43774e828c794215c42b8b45).

--- a/conference-refund-policy/index.md
+++ b/conference-refund-policy/index.md
@@ -11,4 +11,5 @@ description: >
 All ticket purchases for TailscaleUp are final and non-refundable. This applies to all ticket types, including early bird, general admission, and any promotional tickets.
 If you are unable to attend, you may transfer your ticket to another person at no additional cost. The new attendee must meet any applicable eligibility requirements for the ticket type purchased.
 To request a transfer, please email events@tailscale.com with your name, order confirmation number, and the full name and email address of the person who will be attending in your place. Transfer requests must be submitted at least 7 days before the event.
+
 We appreciate your understanding and look forward to seeing you at TailscaleUp.

--- a/conference-refund-policy/index.md
+++ b/conference-refund-policy/index.md
@@ -1,0 +1,14 @@
+---
+title: Conference Refund Policy
+slug: conference-refund-policy
+layout: legal
+description: >
+  Tailscale conference refund policy.
+---
+
+## TAILSCALEUP CONFERENCE REFUND POLICY
+
+All ticket purchases for TailscaleUp are final and non-refundable. This applies to all ticket types, including early bird, general admission, and any promotional tickets.
+If you are unable to attend, you may transfer your ticket to another person at no additional cost. The new attendee must meet any applicable eligibility requirements for the ticket type purchased.
+To request a transfer, please email events@tailscale.com with your name, order confirmation number, and the full name and email address of the person who will be attending in your place. Transfer requests must be submitted at least 7 days before the event.
+We appreciate your understanding and look forward to seeing you at TailscaleUp.

--- a/conference-refund-policy/index.md
+++ b/conference-refund-policy/index.md
@@ -9,7 +9,9 @@ description: >
 ## TAILSCALEUP CONFERENCE REFUND POLICY
 
 All ticket purchases for TailscaleUp are final and non-refundable. This applies to all ticket types, including early bird, general admission, and any promotional tickets.
+
 If you are unable to attend, you may transfer your ticket to another person at no additional cost. The new attendee must meet any applicable eligibility requirements for the ticket type purchased.
+
 To request a transfer, please email events@tailscale.com with your name, order confirmation number, and the full name and email address of the person who will be attending in your place. Transfer requests must be submitted at least 7 days before the event.
 
 We appreciate your understanding and look forward to seeing you at TailscaleUp.


### PR DESCRIPTION
Updates: https://tailscale.atlassian.net/browse/BG-1617
Updates: https://tailscale.atlassian.net/browse/BG-1619

### Context
We need to add two new legal pages for the Tailscaleup conference
- Code of Conduct
  - The content should be the same as this page: https://tailscale.dev/events/code-of-conduct
- Conference refund policy
  - Content is:
  - TAILSCALEUP CONFERENCE REFUND POLICYAll ticket purchases for TailscaleUp are final and non-refundable. This applies to all ticket types, including early bird, general admission, and any promotional tickets.If you are unable to attend, you may transfer your ticket to another person at no additional cost. The new attendee must meet any applicable eligibility requirements for the ticket type purchased.To request a transfer, please email [events@tailscale.com](mailto:events@tailscale.com) with your name, order confirmation number, and the full name and email address of the person who will be attending in your place. Transfer requests must be submitted at least 7 days before the event.We appreciate your understanding and look forward to seeing you at TailscaleUp.[1:36 PM]https://tailscale.dev/events/code-of-conduct

### QA
There are no preview links on this repo, but you can check the markdown files:
- Code of conduct
  - https://github.com/tailscale/terms-and-conditions/blob/ic/BG-1617-1619/adding-legal-pages-for-tailscaleup/code-of-conduct/index.md
- Conference refund policy
  - https://github.com/tailscale/terms-and-conditions/blob/ic/BG-1617-1619/adding-legal-pages-for-tailscaleup/conference-refund-policy/index.md


**Next steps:** add these pages to the legal hub in sanity once they are live